### PR TITLE
Add warning about Abort Battle Command

### DIFF
--- a/McKathlin_GameOver.js
+++ b/McKathlin_GameOver.js
@@ -69,6 +69,9 @@
  *   So if you want to make something happen after a slow fadeout
  *   and return to the map, I recommend using the After Game Over Common Event
  *   instead.
+ * * Using the Abort Battle command in your Party Death Common Event will
+ *   interfere with scene control, so do not use the Abort Battle command
+ *   in a Party Death Common Event that also uses the Game Over command.
  * * If you would like the Game Over screen (or a fadeout and cut to the map
  *   if "Show Game Over Scene" is false) to show at the end of your common
  *   event, remember to use the Game Over command in your common event.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ Here are some pointers:
   So if you want to make something happen after a slow fadeout
   and return to the map, I recommend using the After Game Over Common Event
   instead.
+* Using the Abort Battle command in your Party Death Common Event will
+  interfere with scene control, so do not use the Abort Battle command
+  in a Party Death Common Event that also uses the Game Over command.
 * If you would like the Game Over screen (or a fadeout and cut to the map
   if "Show Game Over Scene" is false) to show at the end of your common
   event, remember to use the Game Over command in your common event.


### PR DESCRIPTION
These changes add a warning that Abort Battle command and Game Over command shouldn't be used together in Party Death Common Event. This warning is added to the README and the plugin help text.